### PR TITLE
Replace deprecated Link `as` prop with direct `href`

### DIFF
--- a/src/components/ColoredLink.tsx
+++ b/src/components/ColoredLink.tsx
@@ -3,7 +3,6 @@ import { HTMLAttributeAnchorTarget } from 'react'
 
 const ColoredLink: React.FC<{
     href: string
-    as?: string
     title?: string
     target?: HTMLAttributeAnchorTarget
     children?: React.ReactNode

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -14,8 +14,7 @@ const PostCard = ({ post }: { post: Post }) => {
             <Calendar /> <FormattedDate date={post.published} />
             &nbsp; - &nbsp;
             <ColoredLink
-                href="/[id]"
-                as={`/${post.id}`}>
+                href={`/${post.id}`}>
                 {post.title}
             </ColoredLink>
         </span>


### PR DESCRIPTION
## Summary
- `PostList.tsx`: `href="/[id]" as={...}` パターンを `href={`/${post.id}`}` に置き換え
- `ColoredLink.tsx`: 不要になった `as` prop の定義を削除

Closes #42 の高優先度タスク「Link の非推奨 `as` prop を `href` に置き換え」

## Test plan
- [x] `pnpm build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)