### PR TITLE
Redesign post list and add pagination

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
 import Container from '@/components/Container'
 import Headline from '@/components/Headline'
+import Pagination from '@/components/Pagination'
 import PostList from '@/components/PostList'
 import { siteDescription, siteTitle } from '@/config'
-import { getPosts } from '@/lib/post'
+import { getPaginatedPosts } from '@/lib/pagination'
 
 const IndexPage: React.FC = async () => {
-    const posts = await getPosts()
+    const { posts, currentPage, totalPages } = await getPaginatedPosts(1)
     return (
         <>
             <Headline title={siteTitle} href={"/"} subtitle={siteDescription} />
             <Container>
                 <PostList posts={posts} />
+                <Pagination currentPage={currentPage} totalPages={totalPages} />
             </Container>
         </>
     )

--- a/src/app/posts/[n]/page.tsx
+++ b/src/app/posts/[n]/page.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import Container from '@/components/Container'
+import Headline from '@/components/Headline'
+import Pagination from '@/components/Pagination'
+import PostList from '@/components/PostList'
+import { siteDescription, siteTitle } from '@/config'
+import { getPaginatedPosts, getTotalPages } from '@/lib/pagination'
+
+type Params = {
+    n: string
+}
+
+export const generateStaticParams = async () => {
+    const totalPages = await getTotalPages()
+    return Array.from({ length: totalPages }, (_, i) => ({
+        n: String(i + 1),
+    })) satisfies Params[]
+}
+
+export const generateMetadata = async ({ params }: { params: Promise<Params> }) => {
+    const { n } = await params
+    return {
+        title: `Posts - Page ${n}`,
+    }
+}
+
+const PostsPage = async ({ params }: { params: Promise<Params> }) => {
+    const { n } = await params
+    const page = Number(n)
+    const { posts, currentPage, totalPages } = await getPaginatedPosts(page)
+
+    return (
+        <>
+            <Headline title={siteTitle} href={"/"} subtitle={siteDescription} />
+            <Container>
+                <PostList posts={posts} />
+                <Pagination currentPage={currentPage} totalPages={totalPages} />
+            </Container>
+        </>
+    )
+}
+
+export default PostsPage

--- a/src/components/MaterialIcon.tsx
+++ b/src/components/MaterialIcon.tsx
@@ -14,5 +14,7 @@ export const Calendar: React.FC = () => <MaterialIcon name='calendar_month' />
 export const Folder: React.FC = () => <MaterialIcon name='folder' />
 export const Tag: React.FC = () => <MaterialIcon name='sell' />
 export const Edit: React.FC = () => <MaterialIcon name='edit' />
+export const NavigateBefore: React.FC = () => <MaterialIcon name='navigate_before' />
+export const NavigateNext: React.FC = () => <MaterialIcon name='navigate_next' />
 
 export default MaterialIcon

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import React from "react";
+import { NavigateBefore, NavigateNext } from "@/components/MaterialIcon";
+import { getPageHref } from "@/lib/pagination";
+
+export type Props = {
+  currentPage: number;
+  totalPages: number;
+};
+
+const Pagination: React.FC<Props> = ({ currentPage, totalPages }) => {
+  if (totalPages <= 1) return null;
+
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
+
+  return (
+    <nav className="flex justify-between items-center mt-10 text-sm">
+      {hasPrev ? (
+        <Link
+          href={getPageHref(currentPage - 1)}
+          className="px-3 py-2 rounded text-orange-600 hover:bg-orange-50"
+        >
+          <NavigateBefore /> Prev
+        </Link>
+      ) : (
+        <span />
+      )}
+
+      {hasNext ? (
+        <Link
+          href={getPageHref(currentPage + 1)}
+          className="px-3 py-2 rounded text-orange-600 hover:bg-orange-50"
+        >
+          Next <NavigateNext />
+        </Link>
+      ) : (
+        <span />
+      )}
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -10,23 +10,38 @@ export type Props = {
 
 const PostCard = ({ post }: { post: Post }) => {
     return (
-        <span>
-            <Calendar /> <FormattedDate date={post.published} />
-            &nbsp; - &nbsp;
-            <ColoredLink
-                href={`/${post.id}`}>
-                {post.title}
-            </ColoredLink>
-        </span>
+        <div className='flex flex-col gap-1.5'>
+            <h2 className='text-lg font-medium leading-snug'>
+                <ColoredLink href={`/${post.id}`}>
+                    {post.title}
+                </ColoredLink>
+            </h2>
+            <div className='flex items-center gap-3 text-sm text-gray-500'>
+                <span className='inline-flex items-center gap-1'>
+                    <Calendar /> <FormattedDate date={post.published} />
+                </span>
+                {post.categories.length > 0 && (
+                    <span className='inline-flex items-center gap-1.5'>
+                        {post.categories.map(category => (
+                            <ColoredLink key={category} href={`/categories/${category}`}>
+                                <span className='inline-block px-2 py-0.5 text-xs rounded-full bg-orange-50 text-orange-700 border border-orange-200'>
+                                    {category}
+                                </span>
+                            </ColoredLink>
+                        ))}
+                    </span>
+                )}
+            </div>
+        </div>
     )
 }
 
 const PostList: React.FC<Props> = ({ posts }) => {
     return (
-        <ul>
+        <ul className='divide-y divide-gray-200'>
             { posts.map(post => {
                 return (
-                    <li key={post.id}>
+                    <li key={post.id} className='py-5 first:pt-0 last:pb-0'>
                         <PostCard post={post} />
                     </li>
                 )

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,33 @@
+import { Post, getPosts } from './post'
+
+const POSTS_PER_PAGE = 10
+
+export type PaginatedPosts = {
+    posts: Post[]
+    currentPage: number
+    totalPages: number
+}
+
+export async function getPaginatedPosts(page: number): Promise<PaginatedPosts> {
+    const allPosts = await getPosts()
+    const totalPages = Math.ceil(allPosts.length / POSTS_PER_PAGE)
+    const start = (page - 1) * POSTS_PER_PAGE
+    const posts = allPosts.slice(start, start + POSTS_PER_PAGE)
+    return { posts, currentPage: page, totalPages }
+}
+
+export function getAllPageNumbers(): number[] {
+    // This is called at build time by generateStaticParams
+    // We can't use async getPosts here easily, so we export this
+    // and let the caller handle it
+    return []
+}
+
+export async function getTotalPages(): Promise<number> {
+    const allPosts = await getPosts()
+    return Math.ceil(allPosts.length / POSTS_PER_PAGE)
+}
+
+export function getPageHref(page: number): string {
+    return page === 1 ? '/' : `/posts/${page}/`
+}


### PR DESCRIPTION
## Summary
- 記事一覧を区切り線スタイルにリデザイン（タイトルを主役に、日付・カテゴリバッジを副次情報として表示）
- Prev/Next ナビゲーション付きのページネーションを追加（10件/ページ、URL: `/posts/[n]/`）
- MaterialIcon に `NavigateBefore` / `NavigateNext` コンポーネントを追加

## Test plan
- [x] トップページ (`/`) で最新10件が表示されることを確認
- [x] `/posts/2/` で次の10件が表示されることを確認
- [x] Prev/Next ボタンが正しいページにリンクしていることを確認
- [x] 1ページ目では Prev が表示されないことを確認
- [x] 最終ページでは Next が表示されないことを確認
- [x] `pnpm build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)